### PR TITLE
[Fix] - fix 'buffer' reference error and add additional filter constraint to empty folders

### DIFF
--- a/src/downloader.js
+++ b/src/downloader.js
@@ -43,8 +43,9 @@ async function downloadNewFiles(auth, files, path) {
 /* HELPER FUNCTIONS FOR DOWNLOADING AND WRITING FILES/FOLDERS */
 
 async function downloadFile(auth, file_id, file_name, base_path) {
+    let buffer;
     try {
-        const buffer = await downloadFileAPI(auth, file_id);
+        buffer = await downloadFileAPI(auth, file_id);
     } catch (err) {
         if (PRINT) console.log("File '" + file_name +"' could not be downloaded.");
         return;
@@ -54,8 +55,9 @@ async function downloadFile(auth, file_id, file_name, base_path) {
 }
 
 async function downloadFolder(auth, folder_id, folder_name, base_path) {
+    let buffer;
     try {
-        const buffer = await downloadFolderAPI(auth, folder_id);
+        buffer = await downloadFolderAPI(auth, folder_id);
     } catch (err) {
         if (PRINT) console.log("Folder '" + folder_name + "' could not be downloaded.");
         return;

--- a/src/exploreLuminusDirectory.js
+++ b/src/exploreLuminusDirectory.js
@@ -37,7 +37,8 @@ async function exploreFolders(auth, parent_id) {
     const foldersInfo = await queryFoldersAPI(auth, parent_id);
     // Filter for folders that aren't submission folders, and are open folders
     const filteredFoldersInfo = foldersInfo.filter(folderInfo => {
-        return !folderInfo['allowUpload'] && folderInfo['totalFileCount'] !== null;
+        return !folderInfo['allowUpload'] && folderInfo['totalFileCount'] !== null 
+            && folderInfo['totalSize'] !== 0;
     });
     const folders = filteredFoldersInfo.map(folderInfo => {
         return new Folder(folderInfo['id'], folderInfo['name'].trim());


### PR DESCRIPTION
Hi, I just happened to bump into this project, and I find it really neat, I would probably use this quite often, and suggest to someone else too. There's just some minor breaks from few months back. 

And downloading empty folders is not possible from the API, so not sure how you will want to handle it. Here, I suggest skipping it directly. Picture shows the result of downloading empty folders.

Thanks!

![image](https://user-images.githubusercontent.com/58265908/89894160-37aca100-dc0c-11ea-9ede-a965ab2ce4d1.png)
