### PR TITLE
Quick fix for forward slashes in folder names

### DIFF
--- a/src/downloader.js
+++ b/src/downloader.js
@@ -64,6 +64,7 @@ async function downloadFolder(auth, folder_id, folder_name, base_path) {
         if (PRINT) console.log("Folder '" + folder_name + "' could not be downloaded.");
         return;
     }
+    folder_name = folder_name.replace(/\//g, ':');  // Replace forward slashes that can mess up the zip file path
     const zip_file_path = path.join(base_path, folder_name + '.zip');
     await writeFile(buffer, zip_file_path);
     await fixBackSlashedZipFile(zip_file_path);


### PR DESCRIPTION
Part of #16

Replaces `/` in zip file names with `:`, so as to not confuse the path. This won't affect the internal contents of the zip file though, so when it's extracted, any `/`s in there will likely be (wrongly) interpreted as additional directories